### PR TITLE
Add prometheus metrics export

### DIFF
--- a/debug.sh
+++ b/debug.sh
@@ -15,6 +15,10 @@ read-data=__PATH__executable__/../../data
 write-data=.
 EOF
 
-factorio --config config.ini testing --start-server-load-scenario fadmin --rcon-bind "$RCON_HOST:$RCON_PORT" --rcon-password "$RCON_PWD" << EOF
-/promote $DEBUG_PLAYER
-EOF
+echo "[\"$DEBUG_PLAYER\"]" > server-adminlist.json
+factorio --config config.ini testing --start-server-load-scenario fadmin --rcon-bind "$RCON_HOST:$RCON_PORT" --rcon-password "$RCON_PWD" &
+
+PID=$!
+echo $PID > $(cd .. && realpath "$FACTORIO_PIDFILE")
+trap "" SIGINT
+wait $PID

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,10 +1,10 @@
 [[package]]
-category = "main"
-description = "Async http client/server framework (asyncio)"
 name = "aiohttp"
+version = "3.6.2"
+description = "Async http client/server framework (asyncio)"
+category = "main"
 optional = false
 python-versions = ">=3.5.3"
-version = "3.6.2"
 
 [package.dependencies]
 async-timeout = ">=3.0,<4.0"
@@ -17,20 +17,20 @@ yarl = ">=1.0,<2.0"
 speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
-category = "main"
-description = "Timeout context manager for asyncio programs"
 name = "async-timeout"
+version = "3.0.1"
+description = "Timeout context manager for asyncio programs"
+category = "main"
 optional = false
 python-versions = ">=3.5.3"
-version = "3.0.1"
 
 [[package]]
-category = "main"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "19.3.0"
+description = "Classes Without Boilerplate"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.3.0"
 
 [package.extras]
 azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
@@ -39,101 +39,113 @@ docs = ["sphinx", "zope.interface"]
 tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
-category = "main"
-description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
+version = "3.0.4"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.0.4"
 
 [[package]]
-category = "main"
-description = "A powerful declarative symmetric parser/builder for binary data"
 name = "construct"
+version = "2.10.56"
+description = "A powerful declarative symmetric parser/builder for binary data"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "2.10.56"
 
 [package.extras]
 extras = ["enum34", "numpy", "arrow", "ruamel.yaml"]
 
 [[package]]
-category = "main"
-description = "A Python wrapper for the Discord API"
 name = "discord.py"
+version = "1.3.4"
+description = "A Python wrapper for the Discord API"
+category = "main"
 optional = false
 python-versions = ">=3.5.3"
-version = "1.3.4"
 
 [package.dependencies]
 aiohttp = ">=3.6.0,<3.7.0"
 websockets = ">=6.0,<7.0 || >7.0,<8.0 || >8.0,<8.0.1 || >8.0.1,<9.0"
 
 [package.extras]
-docs = ["sphinx (1.8.5)", "sphinxcontrib-trio (1.1.1)", "sphinxcontrib-websupport"]
-voice = ["PyNaCl (1.3.0)"]
+docs = ["sphinx (==1.8.5)", "sphinxcontrib-trio (==1.1.1)", "sphinxcontrib-websupport"]
+voice = ["PyNaCl (==1.3.0)"]
 
 [[package]]
-category = "main"
-description = "A simple factorio RCON client"
 name = "factorio-rcon-py"
+version = "0.0.2"
+description = "A simple factorio RCON client"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.0.2"
 
 [package.dependencies]
 construct = "*"
 
 [[package]]
-category = "main"
-description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
+version = "2.9"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
 
 [[package]]
-category = "main"
-description = "multidict implementation"
 name = "multidict"
+version = "4.7.5"
+description = "multidict implementation"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "4.7.5"
 
 [[package]]
+name = "prometheus-client"
+version = "0.10.1"
+description = "Python client for the Prometheus monitoring system."
 category = "main"
-description = "Add .env support to your django/flask apps in development and deployments"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "python-dotenv"
+version = "0.10.5"
+description = "Add .env support to your django/flask apps in development and deployments"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.10.5"
 
 [package.extras]
 cli = ["click (>=5.0)"]
 
 [[package]]
-category = "main"
-description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 name = "websockets"
+version = "8.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+category = "main"
 optional = false
 python-versions = ">=3.6.1"
-version = "8.1"
 
 [[package]]
-category = "main"
-description = "Yet another URL library"
 name = "yarl"
+version = "1.4.2"
+description = "Yet another URL library"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "1.4.2"
 
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "0376d2e2390d3ee7946c6f89a0a9ece11bcf7b6060a0fd4fc977b527803d0c70"
+lock-version = "1.1"
 python-versions = "^3.7"
+content-hash = "457258dcf8fb50b7590fa2cf386ffef340de7fd50a1cb48fb51d551a6759d5e9"
 
 [metadata.files]
 aiohttp = [
@@ -195,6 +207,10 @@ multidict = [
     {file = "multidict-4.7.5-cp38-cp38-win32.whl", hash = "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5"},
     {file = "multidict-4.7.5-cp38-cp38-win_amd64.whl", hash = "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969"},
     {file = "multidict-4.7.5.tar.gz", hash = "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.10.1-py2.py3-none-any.whl", hash = "sha256:030e4f9df5f53db2292eec37c6255957eb76168c6f974e4176c711cf91ed34aa"},
+    {file = "prometheus_client-0.10.1.tar.gz", hash = "sha256:b6c5a9643e3545bcbfd9451766cbaa5d9c67e7303c7bc32c750b6fa70ecb107d"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.10.5.tar.gz", hash = "sha256:f254bfd0c970d64ccbb6c9ebef3667ab301a71473569c991253a481f1c98dddc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = "^3.7"
 "discord.py" = "^1.3.2"
 python-dotenv = "^0.10.1"
 factorio-rcon-py = "^0.0.2"
+prometheus-client = "^0.10.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/scenario/fadmin.lua
+++ b/scenario/fadmin.lua
@@ -1,3 +1,5 @@
+local statistics_exporter = require("statistics_exporter")
+
 on_console_chat = function(event)
   local name
   if event.player_index == nil then
@@ -171,6 +173,10 @@ fadmin.add_commands = function()
       if res ~= nil then
         rcon.print(game.table_to_json(global.events))
         global.events = {}
+      end
+      res = string.match(parameter, 'stats')
+      if res ~= nil then
+        rcon.print(game.table_to_json(statistics_exporter.export()))
       end
       res = string.match(parameter, 'chat (.*)')
       if res ~= nil then

--- a/scenario/statistics_exporter.lua
+++ b/scenario/statistics_exporter.lua
@@ -1,0 +1,38 @@
+-- Taken from Clusterio's statistic_exporter plugin
+
+local statistics = {
+    "item_production_statistics",
+    "fluid_production_statistics",
+    "kill_count_statistics",
+    "entity_build_count_statistics",
+}
+
+local statistics_exporter = {}
+function statistics_exporter.export()
+    local stats = {
+        game_tick = game.tick,
+        player_count = #game.connected_players,
+        game_flow_statistics = {
+            pollution_statistics = {
+                input = game.pollution_statistics.input_counts,
+                output = game.pollution_statistics.output_counts,
+            },
+        },
+        force_flow_statistics = {}
+    }
+    for _, force in pairs(game.forces) do
+        local flow_statistics = {}
+        for _, statName in pairs(statistics) do
+            flow_statistics[statName] = {
+                input = force[statName].input_counts,
+                output = force[statName].output_counts,
+            }
+        end
+        stats.force_flow_statistics[force.name] = flow_statistics
+    end
+
+
+    return stats
+end
+
+return statistics_exporter


### PR DESCRIPTION
Add metrics gathering capability that includes cpu usage, memory usage, online player count, current game tick (for UPS), item/fluid production, and pollution.

For this to work you will need to add the following environment variables
```
FACTORIO_PIDFILE - Path to file containing the pid of the Factorio process to gather CPU and memory stats for
PROMETHEUS_HOST - IP to bind to the metrics export http server on (localhost is recommended)
PROMETHEUS_PORT - Port to bind the metrics export http server on
```

Once that is done you will need to configure Prometheus to pull metrics from the http server that's hosted by this app, and then setup Grafana with a dashboard to display the data.